### PR TITLE
fixed: empty, not empty 구분되지 않던 버그 수정

### DIFF
--- a/src/atoms/AvaliableInfo.js
+++ b/src/atoms/AvaliableInfo.js
@@ -42,11 +42,9 @@ const AvaliableInfo = props => {
         const start_time = {
             year: event.start_time.substring(0, 4),
             month: event.start_time.substring(5, 7),
-            day: event.start_time.substring(8, 10),
-            hour: event.start_time.substring(11, 13),
-            min: event.start_time.substring(14, 16),
+            day: event.start_time.substring(8, 10)
         };
-        if (start_time.year===date.getFullYear() && start_time.month===intToString(date.getMonth()+1) && start_time.day===intToString(date.getDate())){
+        if (start_time.year===date.getFullYear().toString() && start_time.month===intToString(date.getMonth()+1) && start_time.day===intToString(date.getDate())){
             return <NotEmptyEvent room={room} onClick={props.onClick}/>
         }
             return <EmptyEvent room={room} onClick={props.onClick}/>


### PR DESCRIPTION
#### 간결한 설명
- avaliable info에서 empty와 not empty를 구분하는 코드가 정상작동하지 않아 수정했습니다.

#### 관련 두레이 이슈
- 없음
